### PR TITLE
Tiny metadata fix in fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -10,8 +10,8 @@
   ],
   "contact": {
     "homepage": "https://www.curseforge.com/minecraft/mc-mods/addendum-fabric",
-    "sources": "https://github.com/Eltrut-Co/Addendum",
-    "issues": "https://github.com/Eltrut-Co/Addendum/issues"
+    "sources": "https://github.com/Eltrut-Co/Addendum-Fabric",
+    "issues": "https://github.com/Eltrut-Co/Addendum-Fabric/issues"
   },
 
   "license": "LGPLv2.1",


### PR DESCRIPTION
Hi!

I noticed a small problem (I'm guessing it's not intentional?) problem with your metadata in `fabric.mod.json`, the sources file links to the Forge repository. 